### PR TITLE
Classify server and client components

### DIFF
--- a/packages/analyzer/package.json
+++ b/packages/analyzer/package.json
@@ -12,6 +12,6 @@
   },
   "scripts": {
     "build": "tsc -b",
-    "test": "vitest --run --passWithNoTests"
+    "test": "vitest --run"
   }
 }

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -1,2 +1,4 @@
+export * from './lib/classify';
+export * from './lib/classifyFiles';
 export * from './lib/readManifests';
 export * from './types/next-manifest';

--- a/packages/analyzer/src/lib/__tests__/__fixtures__/components/ClientComponent.tsx
+++ b/packages/analyzer/src/lib/__tests__/__fixtures__/components/ClientComponent.tsx
@@ -1,0 +1,5 @@
+'use client';
+
+export function ClientComponent() {
+  return <div>Client</div>;
+}

--- a/packages/analyzer/src/lib/__tests__/__fixtures__/components/ServerComponent.tsx
+++ b/packages/analyzer/src/lib/__tests__/__fixtures__/components/ServerComponent.tsx
@@ -1,0 +1,3 @@
+export function ServerComponent() {
+  return <div>Server</div>;
+}

--- a/packages/analyzer/src/lib/__tests__/classify.test.ts
+++ b/packages/analyzer/src/lib/__tests__/classify.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { classifyComponent } from '../classify';
+
+describe('classifyComponent', () => {
+  it('marks files with use client directive as client components', () => {
+    const result = classifyComponent({
+      fileName: '/tmp/component.tsx',
+      sourceText: `'use client';
+export function Button() { return <button />; }`
+    });
+
+    expect(result).toMatchObject({ kind: 'client', hasUseClientDirective: true });
+  });
+
+  it('defaults to server components when directive absent', () => {
+    const result = classifyComponent({
+      fileName: '/tmp/server.tsx',
+      sourceText: `export async function Page() { return <div />; }`
+    });
+
+    expect(result).toMatchObject({ kind: 'server', hasUseClientDirective: false });
+  });
+});

--- a/packages/analyzer/src/lib/__tests__/classifyFiles.test.ts
+++ b/packages/analyzer/src/lib/__tests__/classifyFiles.test.ts
@@ -1,0 +1,24 @@
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { classifyFiles } from '../classifyFiles';
+
+const COMPONENT_ROOT = join(__dirname, '__fixtures__', 'components');
+
+describe('classifyFiles', () => {
+  it('classifies multiple files', async () => {
+    const result = await classifyFiles({
+      projectRoot: COMPONENT_ROOT,
+      filePaths: [
+        join(COMPONENT_ROOT, 'ClientComponent.tsx'),
+        join(COMPONENT_ROOT, 'ServerComponent.tsx')
+      ]
+    });
+
+    expect(result).toEqual([
+      { filePath: 'ClientComponent.tsx', kind: 'client' },
+      { filePath: 'ServerComponent.tsx', kind: 'server' }
+    ]);
+  });
+});

--- a/packages/analyzer/src/lib/classify.ts
+++ b/packages/analyzer/src/lib/classify.ts
@@ -1,0 +1,39 @@
+import * as ts from 'typescript';
+
+export type ComponentKind = 'server' | 'client';
+
+interface ClassifyComponentOptions {
+  sourceText: string;
+  fileName: string;
+}
+
+interface ClassificationResult {
+  fileName: string;
+  kind: ComponentKind;
+  hasUseClientDirective: boolean;
+}
+
+function hasUseClientDirective(sourceFile: ts.SourceFile): boolean {
+  for (const statement of sourceFile.statements) {
+    if (!ts.isExpressionStatement(statement)) {
+      return false;
+    }
+    if (!ts.isStringLiteral(statement.expression)) {
+      return false;
+    }
+    if (statement.expression.text === 'use client') {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function classifyComponent({ sourceText, fileName }: ClassifyComponentOptions): ClassificationResult {
+  const sourceFile = ts.createSourceFile(fileName, sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const hasDirective = hasUseClientDirective(sourceFile);
+  return {
+    fileName,
+    kind: hasDirective ? 'client' : 'server',
+    hasUseClientDirective: hasDirective
+  };
+}

--- a/packages/analyzer/src/lib/classifyFiles.ts
+++ b/packages/analyzer/src/lib/classifyFiles.ts
@@ -1,0 +1,29 @@
+import { readFile } from 'node:fs/promises';
+import { relative } from 'node:path';
+
+import { classifyComponent, type ComponentKind } from './classify';
+
+export interface ClassifiedFile {
+  filePath: string;
+  kind: ComponentKind;
+}
+
+export interface ClassifyFilesOptions {
+  projectRoot: string;
+  filePaths: string[];
+}
+
+export async function classifyFiles({ projectRoot, filePaths }: ClassifyFilesOptions): Promise<ClassifiedFile[]> {
+  const results = await Promise.all(
+    filePaths.map(async (absPath) => {
+      const sourceText = await readFile(absPath, 'utf8');
+      const classification = classifyComponent({ fileName: absPath, sourceText });
+      return {
+        filePath: relative(projectRoot, absPath) || absPath,
+        kind: classification.kind
+      } satisfies ClassifiedFile;
+    })
+  );
+
+  return results.sort((a, b) => a.filePath.localeCompare(b.filePath));
+}


### PR DESCRIPTION
## Summary
- add a quick AST helper that checks for the 'use client' directive and exports it from the analyzer
- provide classifyFiles to process multiple source files and expose handy fixtures/tests
- switch analyzer test script to run real suites

## Testing
- corepack pnpm -r test

Closes #7