### PR TITLE
Add client forbidden import diagnostics

### DIFF
--- a/packages/analyzer/package.json
+++ b/packages/analyzer/package.json
@@ -13,5 +13,8 @@
   "scripts": {
     "build": "tsc -b",
     "test": "vitest --run"
+  },
+  "dependencies": {
+    "@server-client-xray/schemas": "workspace:*"
   }
 }

--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -2,3 +2,4 @@ export * from './lib/classify';
 export * from './lib/classifyFiles';
 export * from './lib/readManifests';
 export * from './types/next-manifest';
+export * from './rules/clientForbiddenImports';

--- a/packages/analyzer/src/rules/__tests__/clientForbiddenImports.test.ts
+++ b/packages/analyzer/src/rules/__tests__/clientForbiddenImports.test.ts
@@ -1,0 +1,56 @@
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { classifyFiles } from '../../lib/classifyFiles';
+import { analyzeClientFileForForbiddenImports, collectForbiddenImportDiagnostics } from '../clientForbiddenImports';
+
+const COMPONENT_ROOT = join(__dirname, '../../lib/__tests__/__fixtures__/components');
+
+async function loadSource(absolutePath: string) {
+  const fs = await import('node:fs/promises');
+  return fs.readFile(absolutePath, 'utf8');
+}
+
+describe('client forbidden imports', () => {
+  it('flags forbidden imports inside client components', async () => {
+    const sourceText = "'use client';\nimport fs from 'fs';\nexport const Button = () => null;";
+    const diagnostics = analyzeClientFileForForbiddenImports({
+      fileName: 'Client.tsx',
+      sourceText
+    });
+
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]).toMatchObject({
+      rule: 'client-forbidden-import',
+      level: 'error'
+    });
+  });
+
+  it('skips server files automatically', async () => {
+    const sourceText = "import fs from 'fs';\nexport const Server = () => null;";
+    const diagnostics = analyzeClientFileForForbiddenImports({
+      fileName: 'Server.tsx',
+      sourceText
+    });
+
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('collects diagnostics across files', async () => {
+    const filePaths = [
+      join(COMPONENT_ROOT, 'ClientComponent.tsx'),
+      join(COMPONENT_ROOT, 'ServerComponent.tsx')
+    ];
+    const sources = await Promise.all(filePaths.map(loadSource));
+    const classified = await classifyFiles({ projectRoot: COMPONENT_ROOT, filePaths });
+    const files = classified.map((entry, index) => ({
+      filePath: entry.filePath,
+      kind: entry.kind,
+      sourceText: sources[index]
+    }));
+
+    const diagnostics = collectForbiddenImportDiagnostics({ files });
+    expect(diagnostics).toHaveLength(0);
+  });
+});

--- a/packages/analyzer/src/rules/clientForbiddenImports.ts
+++ b/packages/analyzer/src/rules/clientForbiddenImports.ts
@@ -1,0 +1,119 @@
+import * as ts from 'typescript';
+import type { Diagnostic } from '@server-client-xray/schemas';
+
+import { classifyComponent } from '../lib/classify';
+import type { ComponentKind } from '../lib/classify';
+
+export interface AnalyzeClientSourceOptions {
+  fileName: string;
+  sourceText: string;
+  forbiddenModules?: readonly string[];
+}
+
+const DEFAULT_MODULES = new Set([
+  'fs',
+  'path',
+  'child_process',
+  'os',
+  'net',
+  'tls',
+  'http',
+  'https',
+  'worker_threads',
+  'perf_hooks'
+]);
+
+function resolveModuleSet(forbiddenModules?: readonly string[]): Set<string> {
+  return forbiddenModules ? new Set(forbiddenModules) : DEFAULT_MODULES;
+}
+
+function normalizeModule(moduleName: string): string {
+  return moduleName.startsWith('node:') ? moduleName.slice(5) : moduleName;
+}
+
+function isForbiddenModule(moduleName: string, modules: Set<string>): boolean {
+  return modules.has(moduleName) || modules.has(normalizeModule(moduleName));
+}
+
+function createDiagnostic(sourceFile: ts.SourceFile, node: ts.Node, moduleName: string): Diagnostic {
+  const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+  return {
+    rule: 'client-forbidden-import',
+    level: 'error',
+    message: `Client components must not import '${moduleName}'.`,
+    loc: {
+      file: sourceFile.fileName,
+      line: line + 1,
+      col: character + 1
+    }
+  };
+}
+
+function analyzeSource({ fileName, sourceText, forbiddenModules }: AnalyzeClientSourceOptions): Diagnostic[] {
+  const sourceFile = ts.createSourceFile(fileName, sourceText, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const diagnostics: Diagnostic[] = [];
+  const modules = resolveModuleSet(forbiddenModules);
+
+  const visit = (node: ts.Node) => {
+    if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
+      const moduleName = node.moduleSpecifier.text;
+      if (isForbiddenModule(moduleName, modules)) {
+        diagnostics.push(createDiagnostic(sourceFile, node.moduleSpecifier, moduleName));
+      }
+    }
+
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === 'require' &&
+      node.arguments.length > 0 &&
+      ts.isStringLiteral(node.arguments[0])
+    ) {
+      const moduleName = node.arguments[0].text;
+      if (isForbiddenModule(moduleName, modules)) {
+        diagnostics.push(createDiagnostic(sourceFile, node.arguments[0], moduleName));
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return diagnostics;
+}
+
+export interface AnalyzeClientFileOptions {
+  fileName: string;
+  sourceText: string;
+  forbiddenModules?: readonly string[];
+}
+
+export function analyzeClientFileForForbiddenImports({ fileName, sourceText, forbiddenModules }: AnalyzeClientFileOptions): Diagnostic[] {
+  const classification = classifyComponent({ fileName, sourceText });
+  if (classification.kind !== 'client') {
+    return [];
+  }
+  return analyzeSource({ fileName, sourceText, forbiddenModules });
+}
+
+export interface CollectForbiddenImportsOptions {
+  files: Array<{ filePath: string; sourceText: string; kind: ComponentKind }>;
+  forbiddenModules?: readonly string[];
+}
+
+export function collectForbiddenImportDiagnostics({ files, forbiddenModules }: CollectForbiddenImportsOptions): Diagnostic[] {
+  const diagnostics: Diagnostic[] = [];
+  for (const file of files) {
+    if (file.kind !== 'client') continue;
+    diagnostics.push(
+      ...analyzeSource({
+        fileName: file.filePath,
+        sourceText: file.sourceText,
+        forbiddenModules
+      })
+    );
+  }
+  return diagnostics;
+}
+
+export const __testing = { analyzeSource, resolveModuleSet, normalizeModule };


### PR DESCRIPTION
## Summary
- add  rule that blocks server-only modules inside client components
- provide helper to aggregate diagnostics across files and export from analyzer
- cover rule with Vitest fixtures and note status in planning docs

## Testing
- corepack pnpm -r test

Closes #12