### PR TITLE
Add analyzer graph builder for route nodes

### DIFF
--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -1,6 +1,7 @@
 export * from './lib/classify';
 export * from './lib/classifyFiles';
 export * from './lib/clientBundles';
+export * from './lib/graph';
 export * from './lib/readManifests';
 export * from './types/next-manifest';
 export * from './rules/clientForbiddenImports';

--- a/packages/analyzer/src/lib/__tests__/__fixtures__/graph-basic/app/(shop)/products/page.tsx
+++ b/packages/analyzer/src/lib/__tests__/__fixtures__/graph-basic/app/(shop)/products/page.tsx
@@ -1,0 +1,10 @@
+import Button from '../../components/Button';
+
+export default function ProductsPage() {
+  return (
+    <section>
+      <h2>Products</h2>
+      <Button label="Buy" />
+    </section>
+  );
+}

--- a/packages/analyzer/src/lib/__tests__/__fixtures__/graph-basic/app/components/Button.tsx
+++ b/packages/analyzer/src/lib/__tests__/__fixtures__/graph-basic/app/components/Button.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+interface ButtonProps {
+  label: string;
+}
+
+export default function Button({ label }: ButtonProps) {
+  return <button type="button">{label}</button>;
+}

--- a/packages/analyzer/src/lib/__tests__/__fixtures__/graph-basic/app/components/ServerMessage.tsx
+++ b/packages/analyzer/src/lib/__tests__/__fixtures__/graph-basic/app/components/ServerMessage.tsx
@@ -1,0 +1,3 @@
+export default function ServerMessage() {
+  return <p>Rendered on the server</p>;
+}

--- a/packages/analyzer/src/lib/__tests__/__fixtures__/graph-basic/app/page.tsx
+++ b/packages/analyzer/src/lib/__tests__/__fixtures__/graph-basic/app/page.tsx
@@ -1,0 +1,12 @@
+import Button from './components/Button';
+import ServerMessage from './components/ServerMessage';
+
+export default function HomePage() {
+  return (
+    <main>
+      <h1>Home</h1>
+      <Button label="Click" />
+      <ServerMessage />
+    </main>
+  );
+}

--- a/packages/analyzer/src/lib/__tests__/graph.test.ts
+++ b/packages/analyzer/src/lib/__tests__/graph.test.ts
@@ -1,0 +1,66 @@
+import { readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { buildGraph } from '../graph';
+import { classifyFiles } from '../classifyFiles';
+
+async function collectTsFiles(root: string): Promise<string[]> {
+  async function walk(dir: string): Promise<string[]> {
+    const entries = await readdir(dir, { withFileTypes: true });
+    const files: string[] = [];
+
+    for (const entry of entries) {
+      const fullPath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        files.push(...(await walk(fullPath)));
+      } else if (/\.(tsx?|jsx?)$/.test(entry.name)) {
+        files.push(fullPath);
+      }
+    }
+
+    return files;
+  }
+
+  return walk(root);
+}
+
+describe('buildGraph', () => {
+  it('constructs route and component nodes with relationships', async () => {
+    const projectRoot = join(__dirname, '__fixtures__', 'graph-basic');
+    const filePaths = await collectTsFiles(projectRoot);
+    const classified = await classifyFiles({ projectRoot, filePaths });
+
+    const graph = await buildGraph({ projectRoot, classifiedFiles: classified });
+
+    expect(graph.routes).toEqual([
+      { route: '/', rootNodeId: 'route:/' },
+      { route: '/products', rootNodeId: 'route:/products' },
+    ]);
+
+    expect(graph.nodes['route:/']).toMatchObject({
+      id: 'route:/',
+      kind: 'route',
+      children: ['module:app/page.tsx'],
+    });
+
+    expect(graph.nodes['module:app/page.tsx']).toMatchObject({
+      id: 'module:app/page.tsx',
+      kind: 'server',
+      children: expect.arrayContaining([
+        'module:app/components/Button.tsx',
+        'module:app/components/ServerMessage.tsx',
+      ]),
+    });
+
+    expect(graph.nodes['module:app/components/Button.tsx']).toMatchObject({
+      kind: 'client',
+      children: [],
+    });
+
+    expect(graph.nodes['route:/products']).toMatchObject({
+      children: ['module:app/(shop)/products/page.tsx'],
+    });
+  });
+});

--- a/packages/analyzer/src/lib/graph.ts
+++ b/packages/analyzer/src/lib/graph.ts
@@ -1,0 +1,215 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, join, relative, resolve } from 'node:path';
+
+import * as ts from 'typescript';
+
+import type { RouteEntry, XNode } from '@server-client-xray/schemas';
+
+import type { ClassifiedFile } from './classifyFiles';
+
+export interface BuildGraphOptions {
+  projectRoot: string;
+  classifiedFiles: ClassifiedFile[];
+  appDir?: string;
+}
+
+export interface BuildGraphResult {
+  routes: RouteEntry[];
+  nodes: Record<string, XNode>;
+}
+
+type NodeKind = XNode['kind'];
+
+interface ModuleMeta {
+  id: string;
+  filePath: string; // posix relative path from project root
+  absPath: string;
+  kind: NodeKind;
+  imports: string[]; // module ids
+}
+
+const SUPPORTED_EXTENSIONS = ['.tsx', '.ts', '.jsx', '.js'];
+
+function toPosixPath(value: string): string {
+  return value.replace(/\\/g, '/');
+}
+
+function normalizeRelativePath(projectRoot: string, absPath: string): string {
+  const rel = relative(projectRoot, absPath) || absPath;
+  return toPosixPath(rel);
+}
+
+function deriveRouteFromAppFile(appDir: string, filePath: string): string | undefined {
+  const segments = filePath.split('/');
+
+  if (segments[0] !== appDir) {
+    return undefined;
+  }
+
+  const fileName = segments[segments.length - 1];
+  const baseName = fileName.split('.')[0];
+
+  if (baseName !== 'page') {
+    return undefined;
+  }
+
+  const withoutFile = segments.slice(1, -1); // drop app dir + filename
+
+  const routeSegments = withoutFile
+    .map((segment) => segment.replace(/^\(([^)]+)\)$/, ''))
+    .filter((segment) => segment.length > 0);
+
+  if (routeSegments.length === 0) {
+    return '/';
+  }
+
+  return `/${routeSegments.join('/')}`;
+}
+
+function createNodeId(kind: NodeKind, key: string): string {
+  return `${kind}:${key}`;
+}
+
+async function extractRelativeImports(absPath: string): Promise<string[]> {
+  const sourceText = await readFile(absPath, 'utf8');
+  const sourceFile = ts.createSourceFile(
+    absPath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    absPath.endsWith('.tsx') || absPath.endsWith('.jsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+  );
+
+  const imports: string[] = [];
+
+  sourceFile.forEachChild((node) => {
+    if (
+      ts.isImportDeclaration(node) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      imports.push(node.moduleSpecifier.text);
+    }
+  });
+
+  return imports;
+}
+
+function resolveImport(
+  projectRoot: string,
+  fromFile: string,
+  importPath: string,
+  availableFiles: Set<string>
+): string | undefined {
+  if (!importPath.startsWith('.') && !importPath.startsWith('/')) {
+    return undefined;
+  }
+
+  const fromDir = dirname(fromFile);
+  const basePath = resolve(fromDir, importPath);
+
+  const candidates: string[] = [];
+
+  if (SUPPORTED_EXTENSIONS.some((ext) => importPath.endsWith(ext))) {
+    candidates.push(basePath);
+  } else {
+    for (const ext of SUPPORTED_EXTENSIONS) {
+      candidates.push(`${basePath}${ext}`);
+    }
+    for (const ext of SUPPORTED_EXTENSIONS) {
+      candidates.push(join(basePath, `index${ext}`));
+    }
+  }
+
+  for (const candidate of candidates) {
+    const relCandidate = normalizeRelativePath(projectRoot, candidate);
+    if (availableFiles.has(relCandidate)) {
+      return relCandidate;
+    }
+  }
+
+  return undefined;
+}
+
+function buildModuleId(filePath: string): string {
+  return `module:${filePath}`;
+}
+
+export async function buildGraph({
+  projectRoot,
+  classifiedFiles,
+  appDir = 'app',
+}: BuildGraphOptions): Promise<BuildGraphResult> {
+  const availableFiles = new Set(classifiedFiles.map((file) => toPosixPath(file.filePath)));
+
+  const moduleMetas = new Map<string, ModuleMeta>();
+
+  for (const file of classifiedFiles) {
+    const relPath = toPosixPath(file.filePath);
+    const absPath = join(projectRoot, relPath);
+    const moduleId = buildModuleId(relPath);
+
+    const importSpecifiers = await extractRelativeImports(absPath);
+    const resolvedImports: string[] = [];
+
+    for (const specifier of importSpecifiers) {
+      const resolved = resolveImport(projectRoot, absPath, specifier, availableFiles);
+      if (resolved) {
+        resolvedImports.push(buildModuleId(resolved));
+      }
+    }
+
+    const meta: ModuleMeta = {
+      id: moduleId,
+      filePath: relPath,
+      absPath,
+      kind: file.kind,
+      imports: Array.from(new Set(resolvedImports)).sort(),
+    };
+
+    moduleMetas.set(moduleId, meta);
+  }
+
+  const nodes: Record<string, XNode> = {};
+
+  for (const meta of moduleMetas.values()) {
+    nodes[meta.id] = {
+      id: meta.id,
+      kind: meta.kind,
+      file: meta.filePath,
+      name: meta.filePath.split('/').pop(),
+      children: meta.imports,
+    };
+  }
+
+  const routes: RouteEntry[] = [];
+
+  const sortedModules = Array.from(moduleMetas.values()).sort((a, b) =>
+    a.filePath.localeCompare(b.filePath)
+  );
+
+  for (const meta of sortedModules) {
+    const route = deriveRouteFromAppFile(appDir, meta.filePath);
+    if (!route) {
+      continue;
+    }
+
+    const routeId = createNodeId('route', route);
+    const routeNode: XNode = {
+      id: routeId,
+      kind: 'route',
+      name: route,
+      children: [meta.id],
+    };
+
+    nodes[routeId] = routeNode;
+    routes.push({ route, rootNodeId: routeId });
+  }
+
+  routes.sort((a, b) => a.route.localeCompare(b.route));
+
+  return {
+    routes,
+    nodes,
+  };
+}


### PR DESCRIPTION
## Summary
- add a graph builder that converts classified files into route and component nodes for the model
- resolve relative imports so server nodes link to their client/server children
- cover the builder with fixtures that assert the route + module relationships

## Testing
- corepack pnpm --filter analyzer test