### PR TITLE
Fix graph fixtures to avoid JSX build errors

### DIFF
--- a/packages/analyzer/src/lib/__tests__/__fixtures__/graph-basic/app/(shop)/products/page.tsx
+++ b/packages/analyzer/src/lib/__tests__/__fixtures__/graph-basic/app/(shop)/products/page.tsx
@@ -1,10 +1,6 @@
 import Button from '../../components/Button';
 
 export default function ProductsPage() {
-  return (
-    <section>
-      <h2>Products</h2>
-      <Button label="Buy" />
-    </section>
-  );
+  Button({ label: 'Buy' });
+  return 'products-page';
 }

--- a/packages/analyzer/src/lib/__tests__/__fixtures__/graph-basic/app/components/Button.tsx
+++ b/packages/analyzer/src/lib/__tests__/__fixtures__/graph-basic/app/components/Button.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-interface ButtonProps {
+export interface ButtonProps {
   label: string;
 }
 
 export default function Button({ label }: ButtonProps) {
-  return <button type="button">{label}</button>;
+  // Return a string literal instead of JSX to avoid pulling React types in fixtures.
+  return `button:${label}`;
 }

--- a/packages/analyzer/src/lib/__tests__/__fixtures__/graph-basic/app/components/ServerMessage.tsx
+++ b/packages/analyzer/src/lib/__tests__/__fixtures__/graph-basic/app/components/ServerMessage.tsx
@@ -1,3 +1,3 @@
 export default function ServerMessage() {
-  return <p>Rendered on the server</p>;
+  return 'server-message';
 }

--- a/packages/analyzer/src/lib/__tests__/__fixtures__/graph-basic/app/page.tsx
+++ b/packages/analyzer/src/lib/__tests__/__fixtures__/graph-basic/app/page.tsx
@@ -2,11 +2,7 @@ import Button from './components/Button';
 import ServerMessage from './components/ServerMessage';
 
 export default function HomePage() {
-  return (
-    <main>
-      <h1>Home</h1>
-      <Button label="Click" />
-      <ServerMessage />
-    </main>
-  );
+  Button({ label: 'Click' });
+  ServerMessage();
+  return 'home-page';
 }


### PR DESCRIPTION
## Summary
- update analyzer graph builder fixtures to avoid JSX so the TypeScript build doesn't require react types
- keep import relationships the same to satisfy graph tests

## Testing
- corepack pnpm --filter analyzer build
- corepack pnpm -r test