### PR TITLE
Attribute client bundle bytes on analyzer nodes

### DIFF
--- a/packages/analyzer/src/index.ts
+++ b/packages/analyzer/src/index.ts
@@ -1,5 +1,6 @@
 export * from './lib/classify';
 export * from './lib/classifyFiles';
+export * from './lib/attributeBytes';
 export * from './lib/clientBundles';
 export * from './lib/graph';
 export * from './lib/readManifests';

--- a/packages/analyzer/src/lib/__tests__/attributeBytes.test.ts
+++ b/packages/analyzer/src/lib/__tests__/attributeBytes.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ClientComponentBundle } from '../clientBundles';
+import { attributeBytes } from '../attributeBytes';
+
+describe('attributeBytes', () => {
+  it('aggregates bytes by component', () => {
+    const bundles: ClientComponentBundle[] = [
+      {
+        filePath: 'components/Foo.tsx',
+        chunks: ['static/chunks/foo.js'],
+        totalBytes: 1024,
+      },
+      {
+        filePath: 'components/Bar.tsx',
+        chunks: ['static/chunks/bar.js'],
+        totalBytes: 2048,
+      },
+      {
+        filePath: 'components\\Foo.tsx',
+        chunks: ['static/chunks/foo-extra.js'],
+        totalBytes: 512,
+      },
+    ];
+
+    const result = attributeBytes(bundles);
+
+    expect(result).toEqual({
+      'components/Bar.tsx': {
+        totalBytes: 2048,
+        chunks: ['static/chunks/bar.js'],
+      },
+      'components/Foo.tsx': {
+        totalBytes: 1536,
+        chunks: ['static/chunks/foo-extra.js', 'static/chunks/foo.js'],
+      },
+    });
+  });
+
+  it('returns empty record when bundles missing', () => {
+    expect(attributeBytes([])).toEqual({});
+    expect(attributeBytes(undefined)).toEqual({});
+  });
+});

--- a/packages/analyzer/src/lib/__tests__/graph.test.ts
+++ b/packages/analyzer/src/lib/__tests__/graph.test.ts
@@ -48,6 +48,13 @@ describe('buildGraph', () => {
       projectRoot,
       classifiedFiles: classified,
       diagnosticsByFile,
+      clientBundles: [
+        {
+          filePath: 'app/components/Button.tsx',
+          chunks: ['static/chunks/app/button.js'],
+          totalBytes: 3072,
+        },
+      ],
     });
 
     expect(graph.routes).toEqual([
@@ -74,6 +81,7 @@ describe('buildGraph', () => {
       kind: 'client',
       children: [],
       diagnostics: diagnosticsByFile['app/components/Button.tsx'],
+      bytes: 3072,
     });
 
     expect(graph.nodes['route:/products']).toMatchObject({

--- a/packages/analyzer/src/lib/attributeBytes.ts
+++ b/packages/analyzer/src/lib/attributeBytes.ts
@@ -1,0 +1,42 @@
+import type { ClientComponentBundle } from './clientBundles';
+
+export interface NodeBundleBytes {
+  totalBytes: number;
+  chunks: string[];
+}
+
+function toPosix(filePath: string): string {
+  return filePath.replace(/\\/g, '/');
+}
+
+export function attributeBytes(
+  bundles: ClientComponentBundle[] | undefined
+): Record<string, NodeBundleBytes> {
+  if (!bundles || bundles.length === 0) {
+    return {};
+  }
+
+  const map = new Map<string, NodeBundleBytes>();
+
+  for (const bundle of bundles) {
+    const key = toPosix(bundle.filePath);
+    const existing = map.get(key);
+
+    if (existing) {
+      existing.totalBytes += bundle.totalBytes;
+      for (const chunk of bundle.chunks) {
+        if (!existing.chunks.includes(chunk)) {
+          existing.chunks.push(chunk);
+        }
+      }
+      existing.chunks.sort();
+    } else {
+      map.set(key, {
+        totalBytes: bundle.totalBytes,
+        chunks: [...bundle.chunks].sort(),
+      });
+    }
+  }
+
+  return Object.fromEntries(map.entries());
+}


### PR DESCRIPTION
## Summary
- add an attributeBytes helper that aggregates chunk sizes per client module using collectClientComponentBundles output
- extend the graph builder to accept client bundle data and set node bytes for matching modules
- cover aggregation and graph integration with unit tests

## Testing
- corepack pnpm --filter analyzer test
- corepack pnpm --filter analyzer build